### PR TITLE
Use a relative path for dotfiles project

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,10 +1,11 @@
 # Add `~/bin` to the `$PATH`
 export PATH="$HOME/bin:$PATH";
+export DOTFILES_RELATIVE_PATH="~/dotfiles"
 
 # Load the shell dotfiles, and then some:
 # * ~/.path can be used to extend `$PATH`.
 # * ~/.extra can be used for other settings you don’t want to commit.
-for file in ~/.{path,bash_prompt,exports,aliases,functions,extra}; do
+for file in ${DOTFILES_RELATIVE_PATH}/.{path,bash_prompt,exports,aliases,functions,extra}; do
 	[ -r "$file" ] && [ -f "$file" ] && source "$file";
 done;
 unset file;

--- a/.bash_profile
+++ b/.bash_profile
@@ -1,6 +1,5 @@
 # Add `~/bin` to the `$PATH`
 export PATH="$HOME/bin:$PATH";
-export DOTFILES_RELATIVE_PATH="~/dotfiles"
 
 # Load the shell dotfiles, and then some:
 # * ~/.path can be used to extend `$PATH`.

--- a/.macos
+++ b/.macos
@@ -615,7 +615,7 @@ tell application "Terminal"
 	(* Open the custom theme so that it gets added to the list
 	   of available terminal themes (note: this will open two
 	   additional terminal windows). *)
-	do shell script "open '$HOME/init/" & themeName & ".terminal'"
+	do shell script "open '${DOTFILES_RELATIVE_PATH}/init/" & themeName & ".terminal'"
 
 	(* Wait a little bit to ensure that the custom theme is added. *)
 	delay 1
@@ -659,7 +659,7 @@ defaults write com.apple.terminal SecureKeyboardEntry -bool true
 defaults write com.apple.Terminal ShowLineMarks -int 0
 
 # Install the Solarized Dark theme for iTerm
-open "${HOME}/init/Solarized Dark.itermcolors"
+open "${DOTFILES_RELATIVE_PATH}/init/Solarized Dark.itermcolors"
 
 # Don’t display the annoying prompt when quitting iTerm
 defaults write com.googlecode.iterm2 PromptOnQuit -bool false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@ This is a forked repository from [Mathiasbynens](https://github.com/mathiasbynen
 Note: There are 2 branches
  1. master - references master from https://mths.be/dotfiles 
  2. bontrager - my personal perferences and settings
+	
+## Usage
+1. Clone repository in desired directory
+2. Create `.bash_profile` in the home directory
+    `touch ~/.bash_profile`
+3. Update `.bash_profile` to contain the location of the repository and source the repo's bash_profile
+```
+export DOTFILES_RELATIVE_PATH="~/dotfiles"
+source ${DOTFILES_RELATIVE_PATH}/.bash_profile
+```
+4. As of right now the `.gitconfig` needs to be copied over to the home directory in order for the git configurations to work
 
 ## Credit
 


### PR DESCRIPTION
The goal of the PR is to start transitioning the project to no longer depend on being synced with the home dir. In my situation it takes a great deal of concern to simply copy files into the home dir and overwrite any that already exist. 

This starts small with aliases, bash_profile, bash_prompt, etc but does not include all configuration files for external programs that expect the files to be located in the home directory.
- [x] Update bash_profile to look for files in the project path rather than home directory
- [x] Update init to be used relative rather than home directory
- [ ] Copy or symbolically link other config files to home directory [out of scope for this PR]